### PR TITLE
change install/update process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ node_js:
 
 script:
   - npm run setup
-  - npm run endpoint
 
 deploy:
   provider: s3

--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "build": "wget https://github.com/ProjectMirador/mirador/releases/download/v2.6.0/build.zip",
-    "copy": "unzip build.zip && cp -r build/mirador ./",
-    "clean": "rm build.zip && rm -r build",
-    "setup": "npm run build && npm run copy && npm run clean",
-    "endpoint": "wget -O mirador/simpleASEndpoint.js https://raw.githubusercontent.com/ProjectMirador/mirador/develop/js/src/annotations/simpleASEndpoint.js"
+    "copy": "rm -rf mirador && mkdir -p mirador && cp -r node_modules/mirador/dist/* mirador",
+    "endpoint": "wget -O mirador/simpleASEndpoint.js https://raw.githubusercontent.com/ProjectMirador/mirador/develop/js/src/annotations/simpleASEndpoint.js",
+    "setup": "npm run copy && npm run endpoint",
   },
   "author": "",
   "license": "ISC",
-  "dependencies": {}
+  "dependencies": {
+    "mirador": "~2.6.0"
+  }
 }

--- a/pathway_a.html
+++ b/pathway_a.html
@@ -157,7 +157,7 @@
           config: {
             plugins: "image link media directionality",
             toolbar: "bold italic | bullist numlist | link image media | removeformat | ltr rtl",
-            tags: ["test", "test2", "test3", "test4"]
+            tags: ["Abbreviazioni", "Beneventana", "Cacografia", "Capitale libraria", "Carolina", "Chrismon", "Colofoni", "Copisti", "Corsiva nuova", "Datazione (Sec. VIII)", "Datazione (Sec. IX)", "Espunzione", "Ex libris", "Glosse", "Gotica", "Interventi redazionali", "Iotacismo", "Lacune", "Libraria di area franca", "Maiuscola", "Manicule", "Mercantesca", "Minuscola", "Monogrammi", "Note di possesso", "Omissioni", "Onciale", "Pre-umanistica", "Rattoppi", "Riempitivi", "Scritture altomedievali italiane", "Scritture insulari", "Segni di interpunzione", "Segni di paragrafo", "Piè di mosca", "Segni di richiamo", "Semigotica", "Semionciale", "Tachigrafia", "Trascrizioni", "Umanistica", "Visigotica", "A. Berloco (a cura di)"]
           }
 	  }
     },

--- a/pathway_c.html
+++ b/pathway_c.html
@@ -70,7 +70,7 @@
           config: {
             plugins: "image link media directionality",
             toolbar: "bold italic | bullist numlist | link image media | removeformat | ltr rtl",
-            tags: ["test", "test2", "test3"]
+            tags: ["Carolina", "Colofoni", "Copisti", "Corpo del testo", "Datazione (Sec. VIII)", "Datazione (Sec. IX)", "Datazione (Sec. X)", "Enti", "Evangeliari", "Luoghi", "Maiuscola", "Margini", "Minuscola", "Menei", "Menologi", "Notazione musicale", "Onciale", "Salteri", "Scriptio superior", "Scriptio inferior", "Scriptio infima", "Sinassari", "D. Surace (a cura di)"]
           }
 	  }
     },


### PR DESCRIPTION
Okay. I made this against master now. The `.travis.yml` doesn't explicitly `npm install` because presumably that happens already during each build. Incrementing the version number on the dependency, (or if it changes the third number on its own) should get the most recent version of mirador.