### PR TITLE
Update pathways to use annotot

### DIFF
--- a/annotot_endpoint.js
+++ b/annotot_endpoint.js
@@ -69,6 +69,7 @@
         type: 'DELETE',
         dataType: 'json',
         headers: {
+          'Authorization': 'test123'
           // 'X-CSRF-Token': _this.csrfToken()
         },
         contentType: "application/json; charset=utf-8",
@@ -91,12 +92,12 @@
       var annotation = _this.getAnnotationInEndpoint(oaAnnotation);
       
       var annotationID = annotation.annotation['uuid'];
-
       jQuery.ajax({
         url: _this.endpoint + '/' + encodeURIComponent(annotationID),
         type: 'PATCH',
         dataType: 'json',
         headers: {
+          'Authorization': 'test123',
           'X-CSRF-Token': _this.csrfToken()
         },
         data: JSON.stringify(annotation),
@@ -124,6 +125,7 @@
         url: _this.endpoint,
         type: 'POST',
         headers: {
+          'Authorization': 'test123'
           // 'X-CSRF-Token': _this.csrfToken()
         },
         data: JSON.stringify(annotation),

--- a/annotot_endpoint.js
+++ b/annotot_endpoint.js
@@ -1,0 +1,188 @@
+/*
+ * annotationsList - current list of OA Annotations
+ * dfd - Deferred Object
+ * init()
+ * search(options, successCallback, errorCallback)
+ * create(oaAnnotation, successCallback, errorCallback)
+ * update(oaAnnotation, successCallback, errorCallback)
+ * deleteAnnotation(annotationID, successCallback, errorCallback)
+ *
+ * getAnnotationInOA(endpointAnnotation)
+ * getAnnotationInEndpoint(oaAnnotation)
+ */
+(function($){
+
+  $.AnnototEndpoint = function(options) {
+
+    jQuery.extend(this, {
+      dfd:             null,
+      annotationsList: [],  // OA list for Mirador use
+      windowID:        null,
+      eventEmitter:    null
+    }, options);
+
+    this.init();
+  };
+
+  $.AnnototEndpoint.prototype = {
+    init: function() {},
+
+    // Search endpoint for all annotations with a given URI in options
+    search: function(options, successCallback, errorCallback) {
+      var _this = this;
+      _this.annotationsList = [];
+      options.format = 'json'
+
+      jQuery.ajax({
+        url: _this.endpoint,
+        type: 'GET',
+        dataType: 'json',
+        headers: { },
+        data: options,  // options.uri contains the Canvas URI
+        contentType: "application/json; charset=utf-8",
+        success: function(data) {
+          if (typeof successCallback === "function") {
+            successCallback(data);
+          } else {
+            jQuery.each(data, function(index, value) {
+              value.endpoint = _this;
+              _this.annotationsList.push(_this.getAnnotationInOA(value));
+            });
+            _this.dfd.resolve(true);
+          }
+        },
+        error: function(data) {
+          if (typeof errorCallback === "function") {
+            errorCallback(data);
+          } else {
+            console.log("The request for annotations has caused an error for endpoint: " + options.uri);
+          }
+        }
+      });
+    },
+
+    // Delete an annotation by endpoint identifier
+    deleteAnnotation: function(annotationID, successCallback, errorCallback) {
+      var _this = this;
+      jQuery.ajax({
+        url: _this.endpoint + '/' + annotationID,
+        type: 'DELETE',
+        dataType: 'json',
+        headers: {
+          // 'X-CSRF-Token': _this.csrfToken()
+        },
+        contentType: "application/json; charset=utf-8",
+        success: function(data) {
+          if (typeof successCallback === "function") {
+            successCallback();
+          }
+        },
+        error: function(a, b) {
+          if (typeof errorCallback === "function") {
+            errorCallback();
+          }
+        }
+      });
+    },
+
+    // Update an annotation given the OA version
+    update: function(oaAnnotation, successCallback, errorCallback) {
+      var _this = this;
+      var annotation = _this.getAnnotationInEndpoint(oaAnnotation);
+      
+      var annotationID = annotation.annotation['uuid'];
+
+      jQuery.ajax({
+        url: _this.endpoint + '/' + annotationID,
+        type: 'PATCH',
+        dataType: 'json',
+        headers: {
+          'X-CSRF-Token': _this.csrfToken()
+        },
+        data: JSON.stringify(annotation),
+        contentType: "application/json; charset=utf-8",
+        success: function(data) {
+          if (typeof successCallback === "function") {
+            data.endpoint = _this;
+            successCallback(data);
+          }
+        },
+        error: function(a, b, c) {
+          if (typeof errorCallback === "function") {
+            errorCallback();
+          }
+        }
+      });
+    },
+
+    // Takes OA Annotation, gets Endpoint Annotation, and saves
+    // if successful, MUST return the OA rendering of the annotation
+    create: function(oaAnnotation, successCallback, errorCallback) {
+      var _this = this;
+      var annotation = _this.getAnnotationInEndpoint(oaAnnotation);
+      jQuery.ajax({
+        url: _this.endpoint,
+        type: 'POST',
+        headers: {
+          // 'X-CSRF-Token': _this.csrfToken()
+        },
+        data: JSON.stringify(annotation),
+        contentType: "application/json; charset=utf-8",
+        success: function(data) {
+          data.endpoint = _this;
+          if (typeof successCallback === "function") {
+            successCallback(_this.getAnnotationInOA(data));
+          }
+        },
+        error: function() {
+          if (typeof errorCallback === "function") {
+            errorCallback();
+          }
+        }
+      });
+    },
+
+    set: function(prop, value, options) {
+      if (options) {
+        this[options.parent][prop] = value;
+      } else {
+        this[prop] = value;
+      }
+    },
+
+    //Convert Endpoint annotation to OA
+    getAnnotationInOA: function(annotation) {
+      return annotation;
+    },
+
+    // Converts OA Annotation to endpoint format
+    getAnnotationInEndpoint: function(oaAnnotation) {
+      // Generate a new uuid if one is not present
+      if (oaAnnotation['@id'] == null) {
+        oaAnnotation["@id"] = Mirador.genUUID();
+      }
+      
+      canvas = oaAnnotation.on[0].full;
+      var newAnno = jQuery.extend({}, oaAnnotation);
+      delete newAnno.endpoint
+      return {
+        annotation: {
+          uuid: oaAnnotation["@id"],
+          data: JSON.stringify(newAnno),
+          canvas: canvas
+        }
+      };
+    },
+
+    userAuthorize: function(action, annotation) {
+      return true;  // allow all
+    },
+
+    csrfToken: function() {
+      // We need to monkey patch this since $ !== jQuery in Mirador context
+      return jQuery('meta[name=csrf-token]').attr('content');
+    },
+
+  };
+
+}(Mirador));

--- a/annotot_endpoint.js
+++ b/annotot_endpoint.js
@@ -65,7 +65,7 @@
     deleteAnnotation: function(annotationID, successCallback, errorCallback) {
       var _this = this;
       jQuery.ajax({
-        url: _this.endpoint + '/' + annotationID,
+        url: _this.endpoint + '/' + encodeURIComponent(annotationID),
         type: 'DELETE',
         dataType: 'json',
         headers: {
@@ -93,7 +93,7 @@
       var annotationID = annotation.annotation['uuid'];
 
       jQuery.ajax({
-        url: _this.endpoint + '/' + annotationID,
+        url: _this.endpoint + '/' + encodeURIComponent(annotationID),
         type: 'PATCH',
         dataType: 'json',
         headers: {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
     "build": "wget https://github.com/ProjectMirador/mirador/releases/download/v2.6.0/build.zip",
     "copy": "unzip build.zip && cp -r build/mirador ./",
     "clean": "rm build.zip && rm -r build",
-    "setup": "npm run build && npm run copy && npm run clean",
-    "endpoint": "wget -O mirador/simpleASEndpoint.js https://raw.githubusercontent.com/ProjectMirador/mirador/develop/js/src/annotations/simpleASEndpoint.js"
+    "setup": "npm run build && npm run copy && npm run clean"
   },
   "author": "",
   "license": "ISC",

--- a/pathway_a.html
+++ b/pathway_a.html
@@ -17,7 +17,7 @@
     <div id="viewer"></div>
 
     <script src="mirador/mirador.js"></script>
-    <script src="annotot_endpoint.js"></script>
+    <script src="annotot_endpoint.js?version=1"></script>
     <script type="text/javascript">
 
      $(function() {
@@ -82,7 +82,7 @@
 { manifestUri: 'https://digi.vatlib.it/iiif/MSS_Borgh.112/manifest.json', location: 'Borgh.112'},
 { manifestUri: 'https://digi.vatlib.it/iiif/MSS_Chig.L.VIII.296/manifest.json', location: 'Chigi.L.VIII.296'},
 { manifestUri: 'https://digi.vatlib.it/iiif/MSS_Ott.lat.1210/manifest.json', location: 'Ott.lat.1210'},
-{ manifestUri: 'https://digi.vatlib.it/iiif/MSS_Ott.lat.296/manifest.json', location: 'Ott.lat.296'},		 
+{ manifestUri: 'https://digi.vatlib.it/iiif/MSS_Ott.lat.296/manifest.json', location: 'Ott.lat.296'},
 { manifestUri: 'https://digi.vatlib.it/iiif/MSS_Pal.lat.177/manifest.json', location: 'Pal.lat.177'},
 { manifestUri: 'https://digi.vatlib.it/iiif/MSS_Pal.lat.202/manifest.json', location: 'Pal.lat.202'},
 { manifestUri: 'https://digi.vatlib.it/iiif/MSS_Pal.lat.235/manifest.json', location: 'Pal.lat.235'},
@@ -140,14 +140,14 @@
 { manifestUri: 'https://digi.vatlib.it/iiif/MSS_Vat.lat.10969/manifest.json', location: 'Vat.lat.10969'},
 { manifestUri: 'https://digi.vatlib.it/iiif/MSS_Vat.lat.11559/manifest.json', location: 'Vat.lat.11559'},
 { manifestUri: 'https://digi.vatlib.it/iiif/MSS_Vat.lat.12910/manifest.json', location: 'Vat.lat.12910'},
-{ manifestUri: 'https://digi.vatlib.it/iiif/Vat.lat.10696/manifest.json', location: 'Vat.lat.10696'}
+{ manifestUri: 'https://digi.vatlib.it/iiif/MSS_Vat.lat.10696/manifest.json', location: 'Vat.lat.10696'}
 ],
 "windowObjects": [],
     annotationEndpoint: {
       name: 'Annotot',
       module: 'AnnototEndpoint',
       options: {
-        endpoint: 'http://127.0.0.1:3000/annotations'
+        endpoint: 'http://example.com/annotations'
       }
     },
       'annotationBodyEditor': {

--- a/pathway_a.html
+++ b/pathway_a.html
@@ -147,7 +147,7 @@
       name: 'Annotot',
       module: 'AnnototEndpoint',
       options: {
-        endpoint: 'http://colligo.bav.local/annotations'
+        endpoint: 'http://127.0.0.1:3000/annotations'
       }
     },
       'annotationBodyEditor': {
@@ -181,4 +181,3 @@
 </script>
   </body>
 </html>
-

--- a/pathway_b.html
+++ b/pathway_b.html
@@ -113,7 +113,7 @@
       name: 'Annotot',
       module: 'AnnototEndpoint',
       options: {
-        endpoint: 'http://colligo.bav.local/annotations'
+        endpoint: 'http://127.0.0.1:3000/annotations'
       }
     },
       'annotationBodyEditor': {
@@ -147,4 +147,3 @@
 </script>
   </body>
 </html>
-

--- a/pathway_b.html
+++ b/pathway_b.html
@@ -17,7 +17,7 @@
     <div id="viewer"></div>
 
     <script src="mirador/mirador.js"></script>
-    <script src="annotot_endpoint.js"></script>
+    <script src="annotot_endpoint.js?version=1"></script>
     <script type="text/javascript">
 
      $(function() {
@@ -113,7 +113,7 @@
       name: 'Annotot',
       module: 'AnnototEndpoint',
       options: {
-        endpoint: 'http://127.0.0.1:3000/annotations'
+        endpoint: 'http://example.com/annotations'
       }
     },
       'annotationBodyEditor': {

--- a/pathway_c.html
+++ b/pathway_c.html
@@ -61,7 +61,7 @@
       name: 'Annotot',
       module: 'AnnototEndpoint',
       options: {
-        endpoint: 'http://colligo.bav.local/annotations'
+        endpoint: 'http://127.0.0.1:3000/annotations'
       }
     },
       'annotationBodyEditor': {

--- a/pathway_c.html
+++ b/pathway_c.html
@@ -17,7 +17,7 @@
     <div id="viewer"></div>
 
     <script src="mirador/mirador.js"></script>
-    <script src="annotot_endpoint.js"></script>
+    <script src="annotot_endpoint.js?version=1"></script>
     <script type="text/javascript">
 
      $(function() {
@@ -61,7 +61,7 @@
       name: 'Annotot',
       module: 'AnnototEndpoint',
       options: {
-        endpoint: 'http://127.0.0.1:3000/annotations'
+        endpoint: 'http://example.com/annotations'
       }
     },
       'annotationBodyEditor': {

--- a/pathway_d.html
+++ b/pathway_d.html
@@ -65,7 +65,7 @@
       name: 'Annotot',
       module: 'AnnototEndpoint',
       options: {
-        endpoint: 'http://colligo.bav.local/annotations'
+        endpoint: 'http://127.0.0.1:3000/annotations'
       }
     },
       'annotationBodyEditor': {

--- a/pathway_d.html
+++ b/pathway_d.html
@@ -17,7 +17,7 @@
     <div id="viewer"></div>
 
     <script src="mirador/mirador.js"></script>
-    <script src="annotot_endpoint.js"></script>
+    <script src="annotot_endpoint.js?version=1"></script>
     <script type="text/javascript">
 
      $(function() {
@@ -65,7 +65,7 @@
       name: 'Annotot',
       module: 'AnnototEndpoint',
       options: {
-        endpoint: 'http://127.0.0.1:3000/annotations'
+        endpoint: 'http://example.com/annotations'
       }
     },
       'annotationBodyEditor': {


### PR DESCRIPTION
Note: To a local implementer, the annotot endpoint will need to be updated to point to the Colligo instance serving annotations.

```diff
# pathway_*.html
annotationEndpoint: {
      name: 'Annotot',
      module: 'AnnototEndpoint',
      options: {
-        endpoint: 'http://127.0.0.1:3000/annotations'
+        endpoint: 'http://spotlight-url.com/annotations'
      }
    },
```
Add the API key to the `annotot_endpoint.js` file for all endpoints that need authorizaiton.
```diff
        headers: {
+          'Authorization': 'secret api key'
        },
```